### PR TITLE
Update controller to use terraform workspaces for isolation between namespaces

### DIFF
--- a/pkg/controller/module/module_controller.go
+++ b/pkg/controller/module/module_controller.go
@@ -113,6 +113,16 @@ func (r *ReconcileModule) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, err
 	}
 
+	err = terraform.TerraformNewWorkspace(instance.ObjectMeta.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	err = terraform.TerraformSelectWorkspace(instance.ObjectMeta.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	err = terraform.TerraformValidate(instance.ObjectMeta.Namespace)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -84,6 +84,34 @@ func WriteToFile(b []byte, namespace string, name string) error {
 	return nil
 }
 
+func TerraformNewWorkspace(namespace string) error {
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd := exec.Command("terraform", "workspace", "new", namespace)
+	cmd.Dir = TFPATH + "/" + namespace
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	cmd.Run()
+
+	fmt.Println("terraform init output:\n" + out.String())
+	return nil
+}
+
+func TerraformSelectWorkspace(namespace string) error {
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd := exec.Command("terraform", "workspace", "select", namespace)
+	cmd.Dir = TFPATH + "/" + namespace
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	cmd.Run()
+
+	fmt.Println("terraform init output:\n" + out.String())
+	return nil
+}
+
 func TerraformInit(namespace string) error {
 	var out bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
Terraform workspaces are needed for isolation between namespace resources. This is a working-progress change to get the ball rolling on this.