### PR TITLE
Use controller-gen instead of operator-sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 HUB=quay.io/krubot/terraform-operator
 
-all: generate image
+all: generate manifests image
 
 generate:
 	operator-sdk generate k8s
-	operator-sdk generate openapi
+
+manifests: controller-gen
+	$(CONTROLLER_GEN) crd:trivialVersions=true paths="./..." output:crd:artifacts:config=deploy/crds
 
 image:
 	operator-sdk build $(HUB)
@@ -16,5 +18,15 @@ packages:
 
 fmt:
 	go fmt ./...
+
+# find or download controller-gen
+# download controller-gen if necessary
+controller-gen:
+ifeq (, $(shell which controller-gen))
+go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.2
+CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen
+else
+CONTROLLER_GEN=$(shell which controller-gen)
+endif
 
 .PHONY: all image generate

--- a/deploy/crds/terraform.io_backends.yaml
+++ b/deploy/crds/terraform.io_backends.yaml
@@ -1,7 +1,12 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: providers.terraform.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
+  creationTimestamp: null
+  name: backends.terraform.io
 spec:
   additionalPrinterColumns:
   - JSONPath: .status
@@ -10,15 +15,18 @@ spec:
     type: string
   group: terraform.io
   names:
-    kind: Provider
-    listKind: ProviderList
-    plural: providers
-    singular: provider
-  scope: Namespaced
+    kind: Backend
+    listKind: BackendList
+    plural: backends
+    shortNames:
+    - backend
+    singular: backend
+  scope: Cluster
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
+      description: Backend is the Schema for the Backends API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -33,18 +41,27 @@ spec:
         metadata:
           type: object
         spec:
-          description: ProviderSpec defines the desired state of Provider
+          description: BackendSpec defines the desired state of Backend
           properties:
-            host:
-              description: Kubernetes provider hostname (in form of URI) of Kubernetes
-                master
+            cacert_path:
+              description: EtcdV3 backend cacert path
               type: string
-            insecure:
-              description: Kubernetes provider whether server should be accessed without
-                verifying the TLS certificate
+            cert_path:
+              description: EtcdV3 backend cert path
+              type: string
+            endpoints:
+              description: EtcdV3 backend endpoints
+              items:
+                type: string
+              type: array
+            key_path:
+              description: EtcdV3 backend key path
+              type: string
+            lock:
+              description: EtcdV3 backend lock
               type: boolean
-            token:
-              description: Kubernetes provider token of your service account
+            prefix:
+              description: EtcdV3 backend prefix
               type: string
           type: object
         status:
@@ -55,3 +72,9 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/crds/terraform.io_modules.yaml
+++ b/deploy/crds/terraform.io_modules.yaml
@@ -1,7 +1,12 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: backends.terraform.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
+  creationTimestamp: null
+  name: modules.terraform.io
 spec:
   additionalPrinterColumns:
   - JSONPath: .status
@@ -10,15 +15,18 @@ spec:
     type: string
   group: terraform.io
   names:
-    kind: Backend
-    listKind: BackendList
-    plural: backends
-    singular: backend
+    kind: Module
+    listKind: ModuleList
+    plural: modules
+    shortNames:
+    - module
+    singular: module
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
+      description: Module is the Schema for the modules API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -33,27 +41,15 @@ spec:
         metadata:
           type: object
         spec:
-          description: BackendSpec defines the desired state of Backend
+          description: ModuleSpec defines the desired state of Module
           properties:
-            cacert_path:
-              description: EtcdV3 backend cacert path
+            namespace_name:
+              description: Kubernetes namespace name
               type: string
-            cert_path:
-              description: EtcdV3 backend cert path
-              type: string
-            endpoints:
-              description: EtcdV3 backend endpoints
-              items:
-                type: string
-              type: array
-            key_path:
-              description: EtcdV3 backend key path
-              type: string
-            lock:
-              description: EtcdV3 backend lock
-              type: boolean
-            prefix:
-              description: EtcdV3 backend prefix
+            source:
+              description: Kubernetes namespace module source
+              enum:
+              - /var/lib/modules/kubernetes/namespace/
               type: string
           type: object
         status:
@@ -64,3 +60,9 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/crds/terraform.io_providers.yaml
+++ b/deploy/crds/terraform.io_providers.yaml
@@ -1,7 +1,12 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: modules.terraform.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
+  creationTimestamp: null
+  name: providers.terraform.io
 spec:
   additionalPrinterColumns:
   - JSONPath: .status
@@ -10,15 +15,18 @@ spec:
     type: string
   group: terraform.io
   names:
-    kind: Module
-    listKind: ModuleList
-    plural: modules
-    singular: module
-  scope: Namespaced
+    kind: Provider
+    listKind: ProviderList
+    plural: providers
+    shortNames:
+    - provider
+    singular: provider
+  scope: Cluster
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
+      description: Provider is the Schema for the providers API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -33,13 +41,18 @@ spec:
         metadata:
           type: object
         spec:
-          description: ModuleSpec defines the desired state of Module
+          description: ProviderSpec defines the desired state of Provider
           properties:
-            namespace_name:
-              description: Kubernetes namespace name
+            host:
+              description: Kubernetes provider hostname (in form of URI) of Kubernetes
+                master
               type: string
-            source:
-              description: Kubernetes namespace module source
+            insecure:
+              description: Kubernetes provider whether server should be accessed without
+                verifying the TLS certificate
+              type: boolean
+            token:
+              description: Kubernetes provider token of your service account
               type: string
           type: object
         status:
@@ -50,3 +63,9 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208
 	sigs.k8s.io/controller-runtime v0.3.0
+	sigs.k8s.io/controller-tools v0.2.2 // indirect
 )
 
 // Pinned to kubernetes-1.13.4

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,7 @@ github.com/go-openapi/validate v0.17.2/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
+github.com/gobuffalo/envy v1.6.15 h1:OsV5vOpHYUpP7ZLS6sem1y40/lNX1BZj+ynMiRi21lQ=
 github.com/gobuffalo/envy v1.6.15/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v0.0.0-20170330071051-c0656edd0d9e/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -209,8 +210,10 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -238,6 +241,7 @@ github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983 h1:wL11wNW7dhKIcRCHSm4sHKPWz0tt4mwBsVodG7+Xyqg=
 github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/markbates/inflect v1.0.4 h1:5fh1gzTFhfae06u3hzHYO9xe3l3v3nW5Pwt3naLTP5g=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/martinlindhe/base36 v0.0.0-20180729042928-5cda0030da17/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
@@ -320,6 +324,7 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v0.0.0-20151117072312-300106c228d5/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
@@ -331,6 +336,7 @@ github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
@@ -473,6 +479,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190213015956-f7e1b50d2251/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190408170212-12dd9f86f350 h1:0USRhKWpISljvJE8egltEaoJb+VD0IUA4eOH6W1yss8=
 golang.org/x/tools v0.0.0-20190408170212-12dd9f86f350/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -541,6 +548,7 @@ k8s.io/code-generator v0.0.0-20181203235156-f8cba74510f3/go.mod h1:MYiN+ZJZ9HkET
 k8s.io/gengo v0.0.0-20181106084056-51747d6e00da/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a h1:QoHVuRquf80YZ+/bovwxoMO3Q/A3nt3yTgS0/0nejuk=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/helm v2.13.1+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -563,6 +571,7 @@ k8s.io/kubernetes v1.11.8-beta.0.0.20190124204751-3a10094374f2/go.mod h1:ocZa8+6
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 sigs.k8s.io/controller-runtime v0.1.12 h1:ovDq28E64PeY1yR+6H7DthakIC09soiDCrKvfP2tPYo=
 sigs.k8s.io/controller-runtime v0.1.12/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
+sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde h1:ZkaHf5rNYzIB6CB82keKMQNv7xxkqT0ylOBdfJPfi+k=
 sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde/go.mod h1:ATWLRP3WGxuAN9HcT2LaKHReXIH+EZGzRuMHuxjXfhQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=

--- a/pkg/apis/terraform/v1alpha1/backend_types.go
+++ b/pkg/apis/terraform/v1alpha1/backend_types.go
@@ -7,8 +7,8 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// BackendSpec defines the desired state of Backend
 // +kubebuilder:subresource:status
+// BackendSpec defines the desired state of Backend
 type BackendSpec struct {
 	// EtcdV3 backend endpoints
 	// +optional
@@ -30,18 +30,16 @@ type BackendSpec struct {
 	KeyPath string `json:"key_path,omitempty"`
 }
 
-// Backend is the Schema for the Backends API
-
 // +genclient
 // +genclient:nonNamespaced
 // +genclient:skipVerbs=updateStatus
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=backends
+// +kubebuilder:resource:path=backends,singular=backend,scope=Cluster,shortName=backend
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status",description="Description of the current status"
+// Backend is the Schema for the Backends API
 type Backend struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -51,7 +49,7 @@ type Backend struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:object:root=true
 // BackendList contains a list of Backend
 type BackendList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/terraform/v1alpha1/module_types.go
+++ b/pkg/apis/terraform/v1alpha1/module_types.go
@@ -7,27 +7,26 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// ModuleSpec defines the desired state of Module
 // +kubebuilder:subresource:status
+// ModuleSpec defines the desired state of Module
 type ModuleSpec struct {
 	// Kubernetes namespace module source
+	// +kubebuilder:validation:Enum=/var/lib/modules/kubernetes/namespace/
 	Source string `json:"source,omitempty"`
 	// Kubernetes namespace name
 	NamespaceName string `json:"namespace_name,omitempty"`
 }
-
-// Module is the Schema for the modules API
 
 // +genclient
 // +genclient:Namespaced
 // +genclient:skipVerbs=updateStatus
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=modules
+// +kubebuilder:resource:path=modules,singular=module,scope=Namespaced,shortName=module
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status",description="Description of the current status"
+// Module is the Schema for the modules API
 type Module struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -37,7 +36,7 @@ type Module struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:object:root=true
 // ModuleList contains a list of Module
 type ModuleList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/terraform/v1alpha1/provider_types.go
+++ b/pkg/apis/terraform/v1alpha1/provider_types.go
@@ -7,8 +7,8 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// ProviderSpec defines the desired state of Provider
 // +kubebuilder:subresource:status
+// ProviderSpec defines the desired state of Provider
 type ProviderSpec struct {
 	// Kubernetes provider hostname (in form of URI) of Kubernetes master
 	// +optional
@@ -21,18 +21,16 @@ type ProviderSpec struct {
 	Insecure bool `json:"insecure,omitempty"`
 }
 
-// Provider is the Schema for the providers API
-
 // +genclient
 // +genclient:nonNamespaced
 // +genclient:skipVerbs=updateStatus
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=providers
+// +kubebuilder:resource:path=providers,singular=provider,scope=Cluster,shortName=provider
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status",description="Description of the current status"
+// Provider is the Schema for the providers API
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -42,7 +40,7 @@ type Provider struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:object:root=true
 // ProviderList contains a list of Provider
 type ProviderList struct {
 	metav1.TypeMeta `json:",inline"`


### PR DESCRIPTION
Fixes for controller gen to output the correct scope and fix other missing fields in the manifest stage. Will look to completely remove the `operator-sdk` in the future.