### PR TITLE
Upgrade flux and tiller versions to allign with the latest stable

### DIFF
--- a/deploy/manifest/flux.yaml
+++ b/deploy/manifest/flux.yaml
@@ -392,7 +392,7 @@ spec:
         - --update-chart-deps=true
         - --log-release-diffs=false
         - --tiller-namespace=kube-system
-        image: docker.io/fluxcd/helm-operator:0.10.1
+        image: docker.io/fluxcd/helm-operator:1.0.0-rc3
         imagePullPolicy: IfNotPresent
         name: flux-helm-operator
         ports:

--- a/deploy/manifest/helm.yaml
+++ b/deploy/manifest/helm.yaml
@@ -50,7 +50,7 @@ spec:
           value: kube-system
         - name: TILLER_HISTORY_MAX
           value: "10"
-        image: gcr.io/kubernetes-helm/tiller:v2.16.0
+        image: gcr.io/kubernetes-helm/tiller:v2.16.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Use the latest stable version of these tool to deploy resources. Move towards helm 3 so that we won't need tiller in the future. 