### PR TITLE
move function to utility file

### DIFF
--- a/deploy/03-tests/bucket.yaml
+++ b/deploy/03-tests/bucket.yaml
@@ -3,6 +3,6 @@ kind: GCS
 metadata:
   name: test
 spec:
-  source: "/var/lib/modules/gcp/gcs/"
+  source: "/opt/modules/gcp/gcs/"
   name: "<bucket-name>"
   project: "<project>"

--- a/pkg/controller/module_controller.go
+++ b/pkg/controller/module_controller.go
@@ -58,9 +58,15 @@ func (r *ReconcileModule) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		r.Get(context.Background(), types.NamespacedName{Name: "cloud", Namespace: ""}, provider)
 
 		if backend.Status == "Ready" && provider.Status == "Ready" {
+			for {
+				e := "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+				h := map[string][]string{"Metadata-Flavor": {"Google"}}
+				if ret := checkURL(e, h, 200); ret == nil {
+					break
+				}
+			}
 			break
 		}
-
 		time.Sleep(3 * time.Second)
 	}
 


### PR DESCRIPTION
This will check if it's possible to get service account token before starting the reconciliation process. This is a kinda hacky solution to check for external dependencies before moving down to the terraform workflow. In the future this will like get refactored a bit.